### PR TITLE
CFIN-152 Change to the repo name reflected in code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# uoy-app-course-search
+# uoy-api-courses

--- a/docs/index.html
+++ b/docs/index.html
@@ -39,7 +39,7 @@
   window.onload = function() {
     // Begin Swagger UI call region
     const ui = SwaggerUIBundle({
-      url: "https://raw.githubusercontent.com/university-of-york/uoy-app-course-search/master/spec/openAPI.yml",
+      url: "https://raw.githubusercontent.com/university-of-york/uoy-api-courses/master/spec/openAPI.yml",
       dom_id: '#swagger-ui',
       deepLinking: true,
       presets: [


### PR DESCRIPTION
A change to the repository name means the url in the index of the swagger ui needs changing along with the readme file name. 