### PR TITLE
Add Github Workflow for Serverless Deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,10 @@
 name: Deploy to AWS
 
-on: push
+on:
+  push:
+    branches:
+      - staging
+      - master
 
 jobs:
   deploy_to_aws:
@@ -22,10 +26,20 @@ jobs:
         working-directory: api
         run: npm ci
 
-      - name: Deploy to serverless
+      - name: Deploy - staging
+        if: github.ref == 'refs/heads/staging'
         working-directory: api
         run: serverless deploy
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGING_AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCOUNT_ID: ${{ secrets.STAGING_AWS_ACCOUNT_ID }}
+
+      - name: Deploy - production
+        if: github.ref == 'refs/heads/master'
+        working-directory: api
+        run: serverless deploy
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.PRODUCTION_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.PRODUCTION_AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCOUNT_ID: ${{ secrets.PRODUCTION_AWS_ACCOUNT_ID }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,31 @@
+name: Deploy to AWS
+
+on: push
+
+jobs:
+  deploy_to_aws:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Install node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+
+      - name: Check out the application's source code
+        uses: actions/checkout@v2
+
+      - name: Install Serverless
+        run: npm install -g serverless
+
+      - name: Install application dependencies
+        working-directory: api
+        run: npm ci
+
+      - name: Deploy to serverless
+        working-directory: api
+        run: serverless deploy
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: eu-west-1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,4 +28,4 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: eu-west-1
+          AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,0 +1,14 @@
+{
+  "name": "serverless-app",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "serverless-pseudo-parameters": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/serverless-pseudo-parameters/-/serverless-pseudo-parameters-2.5.0.tgz",
+      "integrity": "sha512-A/O49AR8LL6jlnPSmnOTYgL1KqVgskeRla4sVDeS/r5dHFJlwOU5MgFilc7aaQP8NWAwRJANaIS9oiSE3I+VUA==",
+      "dev": true
+    }
+  }
+}

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1,14 +1,5 @@
 {
   "name": "serverless-app",
   "version": "1.0.0",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "serverless-pseudo-parameters": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/serverless-pseudo-parameters/-/serverless-pseudo-parameters-2.5.0.tgz",
-      "integrity": "sha512-A/O49AR8LL6jlnPSmnOTYgL1KqVgskeRla4sVDeS/r5dHFJlwOU5MgFilc7aaQP8NWAwRJANaIS9oiSE3I+VUA==",
-      "dev": true
-    }
-  }
+  "lockfileVersion": 1
 }

--- a/api/package.json
+++ b/api/package.json
@@ -8,5 +8,8 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC"
+  "license": "ISC",
+  "devDependencies": {
+    "serverless-pseudo-parameters": "^2.5.0"
+  }
 }

--- a/api/package.json
+++ b/api/package.json
@@ -9,7 +9,5 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "devDependencies": {
-    "serverless-pseudo-parameters": "^2.5.0"
-  }
+  "devDependencies": {}
 }

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -13,8 +13,6 @@
 
 service: serverless-app
 
-plugins:
-  - serverless-pseudo-parameters
 # app and org for use with dashboard.serverless.com
 #app: your-app-name
 #org: your-org-name
@@ -26,7 +24,7 @@ plugins:
 provider:
   name: aws
   runtime: nodejs12.x
-  cfnRole: arn:aws:iam::#{AWS::AccountId}:role/GithubActionsDeploymentRole
+  cfnRole: arn:aws:iam::${env:AWS_ACCOUNT_ID}:role/GithubActionsDeploymentRole
 
 # you can overwrite defaults here
 #  stage: dev

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -24,6 +24,7 @@ service: serverless-app
 provider:
   name: aws
   runtime: nodejs12.x
+# This role is required to deploy an application to AWS with an ESG Account. See https://wiki.york.ac.uk/display/AWS/AWS%3A+Github+Actions for details.
   cfnRole: arn:aws:iam::${env:AWS_ACCOUNT_ID}:role/GithubActionsDeploymentRole
 
 # you can overwrite defaults here

--- a/api/serverless.yml
+++ b/api/serverless.yml
@@ -12,6 +12,9 @@
 # Happy Coding!
 
 service: serverless-app
+
+plugins:
+  - serverless-pseudo-parameters
 # app and org for use with dashboard.serverless.com
 #app: your-app-name
 #org: your-org-name
@@ -23,6 +26,7 @@ service: serverless-app
 provider:
   name: aws
   runtime: nodejs12.x
+  cfnRole: arn:aws:iam::#{AWS::AccountId}:role/GithubActionsDeploymentRole
 
 # you can overwrite defaults here
 #  stage: dev


### PR DESCRIPTION
In order to deploy locally you will either need to create an environment variable AWS_ACCOUNT_ID or comment out 'provider.cfnRole' for now - there is a bug in the serverless-pseudo-parameters plugin we tried to use to avoid this.