### PR TITLE
CFIN-199 do not use a custom domain in AWS sandbox accounts

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -22,7 +22,18 @@ functions:
   courses:
     handler: src/handler.courses
 
+custom:
+  domainName: ${env:DOMAIN_NAME, ''}
+  sslCertificateArn: ${env:SSL_CERTIFICATE_ARN, ''}
+
 resources:
+
+  Conditions:
+    UseCustomDomainName: !Not
+      - !Equals
+        - ${self:custom.domainName}
+        - ''
+
   Resources:
     # The following would be done magically by Serverless if we were defining
     # the API in the "normal" way, i.e., associating endpoints with functions
@@ -59,15 +70,17 @@ resources:
     # Setup the application's domain name as a custom domain name for API Gateway, then map it to the application's API
     ApiGatewayCustomDomainName:
       Type: AWS::ApiGateway::DomainName
+      Condition: UseCustomDomainName
       Properties:
-        RegionalCertificateArn: ${env:SSL_CERTIFICATE_ARN}
-        DomainName: ${env:DOMAIN_NAME}
+        RegionalCertificateArn: ${self:custom.sslCertificateArn}
+        DomainName: ${self:custom.domainName}
         EndpointConfiguration:
           Types:
             - REGIONAL
 
     BasePathMapping:
       Type: AWS::ApiGateway::BasePathMapping
+      Condition: UseCustomDomainName
       DependsOn: [ApiGatewayDeployment]
       Properties:
         BasePath: ''
@@ -78,7 +91,8 @@ resources:
     # DNS CNAME mapping the application's domain name to the behind-the-scenes domain name for the API
     AppCNAME:
       Type: Custom::CNAME
+      Condition: UseCustomDomainName
       Properties:
         ServiceToken: arn:aws:sns:eu-west-1:230504789214:RequestRecordSet
-        Source: ${env:DOMAIN_NAME}.
+        Source: ${self:custom.domainName}.
         Target: !Join [ '', [ !GetAtt ApiGatewayCustomDomainName.RegionalDomainName, '.' ] ]


### PR DESCRIPTION
This PR follows on from https://github.com/university-of-york/uoy-api-courses/pull/27.

This change defaults the domain name and issued SSL certificate ARN to an empty string if they are not present in the environment variables (otherwise serverless throws an error).

It then uses a condition to determine whether to run the CloudFormation resources related to custom domain names, based on the presence/absence of the domain name environment variable.

I've tested this locally deploying to a sandbox without a domain name and deploying to the dev account with a domain name, with the appropriate environment variables absent/present.

We can next set the appropriate environment variables in the GitHub workflow to activate deploying to a custom domain.