### PR TITLE
BUGFIX - fix setup declaration of jest-fetch-mock

### DIFF
--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,1 +1,1 @@
-jest.mock('node-fetch', ()=> require('jest-fetch-mock'));
+global.fetch = require('jest-fetch-mock').enableMocks();


### PR DESCRIPTION
jest.mock wasn't always overriding fetch, leading to inconsistent test results. This explicitly overrides fetch globally.