### PR TITLE
CFIN-340 Refactoring to reference parts of the FunnelBack URL as constants

### DIFF
--- a/src/constants/UrlAndParameters.js
+++ b/src/constants/UrlAndParameters.js
@@ -1,0 +1,8 @@
+const URL_AND_PARAMETERS = {
+    BASE_URL: "https://www.york.ac.uk/search/",
+    COLLECTION: "york-uni-courses",
+    FORM: "course-search",
+    PROFILE: "_default_preview",
+};
+
+module.exports = URL_AND_PARAMETERS;

--- a/src/constants/UrlParameters.js
+++ b/src/constants/UrlParameters.js
@@ -1,0 +1,7 @@
+const URL_PARAMETERS = {
+    COLLECTION: "york-uni-courses",
+    FORM: "course-search",
+    PROFILE: "_default_preview",
+};
+
+module.exports = URL_PARAMETERS;

--- a/src/constants/UrlParameters.js
+++ b/src/constants/UrlParameters.js
@@ -1,7 +1,0 @@
-const URL_PARAMETERS = {
-    COLLECTION: "york-uni-courses",
-    FORM: "course-search",
-    PROFILE: "_default_preview",
-};
-
-module.exports = URL_PARAMETERS;

--- a/src/handler.test.js
+++ b/src/handler.test.js
@@ -1,8 +1,8 @@
 const { courses } = require("./handler");
 const fetch = require("jest-fetch-mock");
-const { COLLECTION, FORM, PROFILE } = require("./constants/UrlAndParameters");
+const { BASE_URL, COLLECTION, FORM, PROFILE } = require("./constants/UrlAndParameters");
 
-const constantPartOfSearchUrl = `collection=${COLLECTION}&form=${FORM}&profile=${PROFILE}`;
+const constantPartOfSearchUrl = `${BASE_URL}?collection=${COLLECTION}&form=${FORM}&profile=${PROFILE}`;
 
 beforeEach(() => {
     fetch.resetMocks();
@@ -19,7 +19,7 @@ test("Simple query calls Funnelback", async () => {
 
     await courses(event);
 
-    const expectedUrl = "https://www.york.ac.uk/search/?" + constantPartOfSearchUrl + "&query=maths";
+    const expectedUrl = constantPartOfSearchUrl + "&query=maths";
 
     expect(fetch.mock.calls[0][0]).toEqual(expectedUrl);
     expect(fetch.mock.calls[0][1].method).toEqual("GET");
@@ -37,7 +37,7 @@ test("Request with max parameter correctly calls Funnelback", async () => {
 
     await courses(event);
 
-    const expectedUrl = "https://www.york.ac.uk/search/?" + constantPartOfSearchUrl + "&query=biology&num_ranks=5";
+    const expectedUrl = constantPartOfSearchUrl + "&query=biology&num_ranks=5";
 
     expect(fetch.mock.calls[0][0]).toEqual(expectedUrl);
     expect(fetch.mock.calls[0][1].method).toEqual("GET");
@@ -55,7 +55,7 @@ test("Request with offset parameter correctly calls Funnelback", async () => {
 
     await courses(event);
 
-    const expectedUrl = "https://www.york.ac.uk/search/?" + constantPartOfSearchUrl + "&query=chemistry&start_rank=10";
+    const expectedUrl = constantPartOfSearchUrl + "&query=chemistry&start_rank=10";
 
     expect(fetch.mock.calls[0][0]).toEqual(expectedUrl);
     expect(fetch.mock.calls[0][1].method).toEqual("GET");
@@ -74,8 +74,7 @@ test("Request with max & offset parameters correctly calls Funnelback", async ()
 
     await courses(event);
 
-    const expectedUrl =
-        "https://www.york.ac.uk/search/?" + constantPartOfSearchUrl + "&query=english&num_ranks=10&start_rank=12";
+    const expectedUrl = constantPartOfSearchUrl + "&query=english&num_ranks=10&start_rank=12";
 
     expect(fetch.mock.calls[0][0]).toEqual(expectedUrl);
     expect(fetch.mock.calls[0][1].method).toEqual("GET");

--- a/src/handler.test.js
+++ b/src/handler.test.js
@@ -1,6 +1,6 @@
 const { courses } = require("./handler");
 const fetch = require("jest-fetch-mock");
-const { COLLECTION, FORM, PROFILE } = require("./constants/UrlParameters");
+const { COLLECTION, FORM, PROFILE } = require("./constants/UrlAndParameters");
 
 const constantPartOfSearchUrl = `collection=${COLLECTION}&form=${FORM}&profile=${PROFILE}`;
 

--- a/src/handler.test.js
+++ b/src/handler.test.js
@@ -1,5 +1,8 @@
 const { courses } = require("./handler");
 const fetch = require("jest-fetch-mock");
+const { COLLECTION, FORM, PROFILE } = require("./constants/UrlParameters");
+
+const constantPartOfSearchUrl = `collection=${COLLECTION}&form=${FORM}&profile=${PROFILE}`;
 
 beforeEach(() => {
     fetch.resetMocks();
@@ -16,8 +19,7 @@ test("Simple query calls Funnelback", async () => {
 
     await courses(event);
 
-    const expectedUrl =
-        "https://www.york.ac.uk/search/?collection=york-uni-courses&form=course-search&profile=_default&query=maths";
+    const expectedUrl = "https://www.york.ac.uk/search/?" + constantPartOfSearchUrl + "&query=maths";
 
     expect(fetch.mock.calls[0][0]).toEqual(expectedUrl);
     expect(fetch.mock.calls[0][1].method).toEqual("GET");
@@ -35,8 +37,7 @@ test("Request with max parameter correctly calls Funnelback", async () => {
 
     await courses(event);
 
-    const expectedUrl =
-        "https://www.york.ac.uk/search/?collection=york-uni-courses&form=course-search&profile=_default&query=biology&num_ranks=5";
+    const expectedUrl = "https://www.york.ac.uk/search/?" + constantPartOfSearchUrl + "&query=biology&num_ranks=5";
 
     expect(fetch.mock.calls[0][0]).toEqual(expectedUrl);
     expect(fetch.mock.calls[0][1].method).toEqual("GET");
@@ -54,8 +55,7 @@ test("Request with offset parameter correctly calls Funnelback", async () => {
 
     await courses(event);
 
-    const expectedUrl =
-        "https://www.york.ac.uk/search/?collection=york-uni-courses&form=course-search&profile=_default&query=chemistry&start_rank=10";
+    const expectedUrl = "https://www.york.ac.uk/search/?" + constantPartOfSearchUrl + "&query=chemistry&start_rank=10";
 
     expect(fetch.mock.calls[0][0]).toEqual(expectedUrl);
     expect(fetch.mock.calls[0][1].method).toEqual("GET");
@@ -75,7 +75,7 @@ test("Request with max & offset parameters correctly calls Funnelback", async ()
     await courses(event);
 
     const expectedUrl =
-        "https://www.york.ac.uk/search/?collection=york-uni-courses&form=course-search&profile=_default&query=english&num_ranks=10&start_rank=12";
+        "https://www.york.ac.uk/search/?" + constantPartOfSearchUrl + "&query=english&num_ranks=10&start_rank=12";
 
     expect(fetch.mock.calls[0][0]).toEqual(expectedUrl);
     expect(fetch.mock.calls[0][1].method).toEqual("GET");

--- a/src/utils/constructFunnelbackUrls.js
+++ b/src/utils/constructFunnelbackUrls.js
@@ -1,6 +1,7 @@
 const { URLSearchParams } = require("url");
 const ClientError = require("../errors/ClientError");
 const BASE_URL = "https://www.york.ac.uk/search/";
+const { COLLECTION, FORM, PROFILE } = require("../constants/UrlParameters");
 
 module.exports.coursesUrl = (parameters) => {
     if (!parameters || !parameters.search) {
@@ -9,9 +10,9 @@ module.exports.coursesUrl = (parameters) => {
 
     const queryParams = new URLSearchParams();
 
-    queryParams.append("collection", "york-uni-courses");
-    queryParams.append("form", "course-search");
-    queryParams.append("profile", "_default");
+    queryParams.append("collection", COLLECTION);
+    queryParams.append("form", FORM);
+    queryParams.append("profile", PROFILE);
     queryParams.append("query", parameters.search);
 
     if (parameters.max) {

--- a/src/utils/constructFunnelbackUrls.js
+++ b/src/utils/constructFunnelbackUrls.js
@@ -1,7 +1,6 @@
 const { URLSearchParams } = require("url");
 const ClientError = require("../errors/ClientError");
-const BASE_URL = "https://www.york.ac.uk/search/";
-const { COLLECTION, FORM, PROFILE } = require("../constants/UrlParameters");
+const { BASE_URL, COLLECTION, FORM, PROFILE } = require("../constants/UrlAndParameters");
 
 module.exports.coursesUrl = (parameters) => {
     if (!parameters || !parameters.search) {

--- a/src/utils/constructFunnelbackUrls.test.js
+++ b/src/utils/constructFunnelbackUrls.test.js
@@ -1,5 +1,8 @@
 const { coursesUrl } = require("./constructFunnelbackUrls");
 const ClientError = require("../errors/ClientError");
+const { COLLECTION, FORM, PROFILE } = require("../constants/UrlParameters");
+
+const constantPartOfSearchUrl = `collection=${COLLECTION}&form=${FORM}&profile=${PROFILE}`;
 
 test("Call without parameters throws ClientError", async () => {
     expect(() => {
@@ -30,8 +33,7 @@ test("Call with search parameter returns correct URL", async () => {
         search: "Maths",
     };
 
-    const expectedUrl =
-        "https://www.york.ac.uk/search/?collection=york-uni-courses&form=course-search&profile=_default&query=Maths";
+    const expectedUrl = "https://www.york.ac.uk/search/?" + constantPartOfSearchUrl + "&query=Maths";
 
     expect(coursesUrl(parameters)).toEqual(expectedUrl);
 });
@@ -42,8 +44,7 @@ test("Call with search & max parameters returns correct URL", async () => {
         max: 12,
     };
 
-    const expectedUrl =
-        "https://www.york.ac.uk/search/?collection=york-uni-courses&form=course-search&profile=_default&query=Maths&num_ranks=12";
+    const expectedUrl = "https://www.york.ac.uk/search/?" + constantPartOfSearchUrl + "&query=Maths&num_ranks=12";
 
     expect(coursesUrl(parameters)).toEqual(expectedUrl);
 });
@@ -54,8 +55,7 @@ test("Call with search & offset parameters returns correct URL", async () => {
         offset: 25,
     };
 
-    const expectedUrl =
-        "https://www.york.ac.uk/search/?collection=york-uni-courses&form=course-search&profile=_default&query=Maths&start_rank=25";
+    const expectedUrl = "https://www.york.ac.uk/search/?" + constantPartOfSearchUrl + "&query=Maths&start_rank=25";
 
     expect(coursesUrl(parameters)).toEqual(expectedUrl);
 });
@@ -68,7 +68,7 @@ test("Call with search, max & offset parameters returns correct URL", async () =
     };
 
     const expectedUrl =
-        "https://www.york.ac.uk/search/?collection=york-uni-courses&form=course-search&profile=_default&query=Maths&num_ranks=18&start_rank=15";
+        "https://www.york.ac.uk/search/?" + constantPartOfSearchUrl + "&query=Maths&num_ranks=18&start_rank=15";
 
     expect(coursesUrl(parameters)).toEqual(expectedUrl);
 });

--- a/src/utils/constructFunnelbackUrls.test.js
+++ b/src/utils/constructFunnelbackUrls.test.js
@@ -1,8 +1,8 @@
 const { coursesUrl } = require("./constructFunnelbackUrls");
 const ClientError = require("../errors/ClientError");
-const { COLLECTION, FORM, PROFILE } = require("../constants/UrlParameters");
+const { BASE_URL, COLLECTION, FORM, PROFILE } = require("../constants/UrlAndParameters");
 
-const constantPartOfSearchUrl = `collection=${COLLECTION}&form=${FORM}&profile=${PROFILE}`;
+const constantPartOfSearchUrl = `${BASE_URL}?collection=${COLLECTION}&form=${FORM}&profile=${PROFILE}`;
 
 test("Call without parameters throws ClientError", async () => {
     expect(() => {
@@ -33,7 +33,7 @@ test("Call with search parameter returns correct URL", async () => {
         search: "Maths",
     };
 
-    const expectedUrl = "https://www.york.ac.uk/search/?" + constantPartOfSearchUrl + "&query=Maths";
+    const expectedUrl = constantPartOfSearchUrl + "&query=Maths";
 
     expect(coursesUrl(parameters)).toEqual(expectedUrl);
 });
@@ -44,7 +44,7 @@ test("Call with search & max parameters returns correct URL", async () => {
         max: 12,
     };
 
-    const expectedUrl = "https://www.york.ac.uk/search/?" + constantPartOfSearchUrl + "&query=Maths&num_ranks=12";
+    const expectedUrl = constantPartOfSearchUrl + "&query=Maths&num_ranks=12";
 
     expect(coursesUrl(parameters)).toEqual(expectedUrl);
 });
@@ -55,7 +55,7 @@ test("Call with search & offset parameters returns correct URL", async () => {
         offset: 25,
     };
 
-    const expectedUrl = "https://www.york.ac.uk/search/?" + constantPartOfSearchUrl + "&query=Maths&start_rank=25";
+    const expectedUrl = constantPartOfSearchUrl + "&query=Maths&start_rank=25";
 
     expect(coursesUrl(parameters)).toEqual(expectedUrl);
 });
@@ -67,8 +67,7 @@ test("Call with search, max & offset parameters returns correct URL", async () =
         offset: 15,
     };
 
-    const expectedUrl =
-        "https://www.york.ac.uk/search/?" + constantPartOfSearchUrl + "&query=Maths&num_ranks=18&start_rank=15";
+    const expectedUrl = constantPartOfSearchUrl + "&query=Maths&num_ranks=18&start_rank=15";
 
     expect(coursesUrl(parameters)).toEqual(expectedUrl);
 });


### PR DESCRIPTION

* so if wanting to eg. try out the default preview search version, just need to change once rather than in all the tests