### PR TITLE
CFIN-340 & CFIN-342 Log and ignore returned non course entries, log other errors

### DIFF
--- a/src/constants/UrlParameters.js
+++ b/src/constants/UrlParameters.js
@@ -1,7 +1,7 @@
 const URL_PARAMETERS = {
     COLLECTION: "york-uni-courses",
     FORM: "course-search",
-    PROFILE: "_default_preview",
+    PROFILE: "_default",
 };
 
 module.exports = URL_PARAMETERS;

--- a/src/handler.js
+++ b/src/handler.js
@@ -17,9 +17,9 @@ module.exports.courses = async (event) => {
         });
 
         if (!searchResponse.ok) {
-            console.log("Funnelback search problem");
-            console.log(url);
-            console.log(searchResponse.statusText);
+            console.error("Funnelback search problem");
+            console.error(url);
+            console.error(searchResponse.statusText);
             return error(
                 "There is a problem with the Funnelback search.",
                 searchResponse.status,
@@ -29,11 +29,12 @@ module.exports.courses = async (event) => {
         }
 
         const body = await searchResponse.json();
-        const results = transformResponse(body.results);
+        const transformedResults = transformResponse(body.results);
+        const results = transformedResults.filter(Boolean); // Removes null values
 
         return success({ results });
     } catch (e) {
-        console.log(e);
+        console.error(e);
         switch (e.constructor.name) {
             case ClientError.name:
                 return error(e.message, 400, "Bad Request", event.path);

--- a/src/handler.js
+++ b/src/handler.js
@@ -29,8 +29,7 @@ module.exports.courses = async (event) => {
         }
 
         const body = await searchResponse.json();
-        const transformedResults = transformResponse(body.results);
-        const results = transformedResults.filter(Boolean); // Removes null values
+        const results = transformResponse(body.results);
 
         return success({ results });
     } catch (e) {

--- a/src/handler.js
+++ b/src/handler.js
@@ -17,7 +17,15 @@ module.exports.courses = async (event) => {
         });
 
         if (!searchResponse.ok) {
-            return error("An error has occurred.", searchResponse.status, searchResponse.statusText, event.path);
+            console.log("Funnelback search problem");
+            console.log(url);
+            console.log(searchResponse.statusText);
+            return error(
+                "There is a problem with the Funnelback search.",
+                searchResponse.status,
+                searchResponse.statusText,
+                event.path
+            );
         }
 
         const body = await searchResponse.json();
@@ -25,6 +33,7 @@ module.exports.courses = async (event) => {
 
         return success({ results });
     } catch (e) {
+        console.log(e);
         switch (e.constructor.name) {
             case ClientError.name:
                 return error(e.message, 400, "Bad Request", event.path);

--- a/src/handler.test.js
+++ b/src/handler.test.js
@@ -150,6 +150,107 @@ test("Response results are transformed to match openAPI spec", async () => {
     expect(result.statusCode).toBe(200);
     expect(result.body).toEqual(JSON.stringify(expectedResult));
 });
+test("Response results do not contain entries from Funnelback that have no department", async () => {
+    const event = {
+        queryStringParameters: {
+            search: "physics",
+        },
+    };
+    const searchResults = {
+        results: [
+            {
+                title: "Maths and Computer Science",
+                liveUrl: "https://www.york.ac.uk/study/undergraduate/courses/mmath-mathematics-computer-science/",
+                award: "MMath (Hons)",
+                department: "Department of Computer Science, Department of Mathematics",
+                level: "undergraduate",
+                length: "4 years full-time",
+                typicalOffer: "AAA-AAB",
+                yearOfEntry: "2021/22",
+                distanceLearning: "No",
+                summary:
+                    "Study complementary subjects to become fluent in both.|Study complementary subjects to become fluent in both.",
+                imageUrl:
+                    "https://www.york.ac.uk/media/study/courses/undergraduate/computerscience/mmath-maths-cs-banner.jpg|https://www.york.ac.uk/media/study/courses/undergraduate/computerscience/mmath-maths-cs-banner.jpg",
+                ucasCode: "GG14",
+            },
+            {
+                title: "Teaching and Learning",
+                liveUrl: "https://www.york.ac.uk/study/undergraduate/courses/teaching-learning/",
+                award: null,
+                department: null,
+                level: null,
+                length: null,
+                typicalOffer: "N/A",
+                yearOfEntry: null,
+                distanceLearning: null,
+                summary: null,
+                imageUrl: "https://www.york.ac.uk|https://www.york.ac.uk",
+                ucasCode: null,
+            },
+            {
+                title: "Physics",
+                liveUrl: "https://www.york.ac.uk/study/undergraduate/courses/mphys-physics/",
+                award: "MPhys (Hons)",
+                department: "Department of Physics",
+                level: "undergraduate",
+                length: "4 years full-time",
+                typicalOffer: "AAA",
+                yearOfEntry: "2021/22",
+                distanceLearning: "No",
+                summary:
+                    "Accelerate towards a career as a professional physicist in industry or academia. |Accelerate towards a career as a professional physicist in industry or academia. ",
+                imageUrl:
+                    "https://www.york.ac.uk/media/study/courses/undergraduate/physics/hero-physics-mphys-1160.jpg|https://www.york.ac.uk/media/study/courses/undergraduate/physics/hero-physics-mphys-1160.jpg",
+                ucasCode: "F303",
+            },
+        ],
+    };
+
+    const expectedResult = {
+        results: [
+            {
+                title: "Maths and Computer Science",
+                liveUrl: "https://www.york.ac.uk/study/undergraduate/courses/mmath-mathematics-computer-science/",
+                award: "MMath (Hons)",
+                department: ["Department of Computer Science", "Department of Mathematics"],
+                level: "undergraduate",
+                length: "4 years full-time",
+                typicalOffer: "AAA-AAB",
+                yearOfEntry: "2021/22",
+                distanceLearning: false,
+                summary:
+                    "Study complementary subjects to become fluent in both.|Study complementary subjects to become fluent in both.",
+                imageUrl:
+                    "https://www.york.ac.uk/media/study/courses/undergraduate/computerscience/mmath-maths-cs-banner.jpg|https://www.york.ac.uk/media/study/courses/undergraduate/computerscience/mmath-maths-cs-banner.jpg",
+                ucasCode: "GG14",
+            },
+            {
+                title: "Physics",
+                liveUrl: "https://www.york.ac.uk/study/undergraduate/courses/mphys-physics/",
+                award: "MPhys (Hons)",
+                department: ["Department of Physics"],
+                level: "undergraduate",
+                length: "4 years full-time",
+                typicalOffer: "AAA",
+                yearOfEntry: "2021/22",
+                distanceLearning: false,
+                summary:
+                    "Accelerate towards a career as a professional physicist in industry or academia. |Accelerate towards a career as a professional physicist in industry or academia. ",
+                imageUrl:
+                    "https://www.york.ac.uk/media/study/courses/undergraduate/physics/hero-physics-mphys-1160.jpg|https://www.york.ac.uk/media/study/courses/undergraduate/physics/hero-physics-mphys-1160.jpg",
+                ucasCode: "F303",
+            },
+        ],
+    };
+
+    fetch.mockResponse(JSON.stringify(searchResults), { status: 200 });
+
+    const result = await courses(event);
+
+    expect(result.statusCode).toBe(200);
+    expect(result.body).toEqual(JSON.stringify(expectedResult));
+});
 
 test("Request without any parameters returns an appropriate error", async () => {
     const result = await courses({});

--- a/src/handler.test.js
+++ b/src/handler.test.js
@@ -150,7 +150,7 @@ test("Response results are transformed to match openAPI spec", async () => {
     expect(result.statusCode).toBe(200);
     expect(result.body).toEqual(JSON.stringify(expectedResult));
 });
-test("Response results do not contain entries from Funnelback that have no department", async () => {
+test("Response results from Funnelback with missing metadata are returned OK", async () => {
     const event = {
         queryStringParameters: {
             search: "physics",
@@ -224,6 +224,20 @@ test("Response results do not contain entries from Funnelback that have no depar
                 imageUrl:
                     "https://www.york.ac.uk/media/study/courses/undergraduate/computerscience/mmath-maths-cs-banner.jpg|https://www.york.ac.uk/media/study/courses/undergraduate/computerscience/mmath-maths-cs-banner.jpg",
                 ucasCode: "GG14",
+            },
+            {
+                title: "Teaching and Learning",
+                liveUrl: "https://www.york.ac.uk/study/undergraduate/courses/teaching-learning/",
+                award: null,
+                department: [],
+                level: null,
+                length: null,
+                typicalOffer: "N/A",
+                yearOfEntry: null,
+                distanceLearning: false,
+                summary: null,
+                imageUrl: "https://www.york.ac.uk|https://www.york.ac.uk",
+                ucasCode: null,
             },
             {
                 title: "Physics",

--- a/src/handler.test.js
+++ b/src/handler.test.js
@@ -159,6 +159,58 @@ test("Response results from Funnelback with missing metadata are returned OK", a
     const searchResults = {
         results: [
             {
+                title: "Teaching and Learning",
+                liveUrl: "https://www.york.ac.uk/study/undergraduate/courses/teaching-learning/",
+                award: null,
+                department: null,
+                level: null,
+                length: null,
+                typicalOffer: "N/A",
+                yearOfEntry: null,
+                distanceLearning: null,
+                summary: null,
+                imageUrl: "https://www.york.ac.uk|https://www.york.ac.uk",
+                ucasCode: null,
+            },
+        ],
+    };
+
+    const expectedResult = {
+        results: [
+            {
+                title: "Teaching and Learning",
+                liveUrl: "https://www.york.ac.uk/study/undergraduate/courses/teaching-learning/",
+                award: null,
+                department: [],
+                level: null,
+                length: null,
+                typicalOffer: "N/A",
+                yearOfEntry: null,
+                distanceLearning: false,
+                summary: null,
+                imageUrl: "https://www.york.ac.uk|https://www.york.ac.uk",
+                ucasCode: null,
+            },
+        ],
+    };
+
+    fetch.mockResponse(JSON.stringify(searchResults), { status: 200 });
+
+    const result = await courses(event);
+
+    expect(result.statusCode).toBe(200);
+    expect(result.body).toEqual(JSON.stringify(expectedResult));
+});
+
+test("Multiple response results are transformed and returned OK", async () => {
+    const event = {
+        queryStringParameters: {
+            search: "physics",
+        },
+    };
+    const searchResults = {
+        results: [
+            {
                 title: "Maths and Computer Science",
                 liveUrl: "https://www.york.ac.uk/study/undergraduate/courses/mmath-mathematics-computer-science/",
                 award: "MMath (Hons)",

--- a/src/handler.test.js
+++ b/src/handler.test.js
@@ -176,7 +176,7 @@ test("Response with 400 code returns an error", async () => {
     expect(result.statusCode).toBe(400);
     expect(result.body).toContain('"status":400');
     expect(result.body).toContain('"error":"Bad Request"');
-    expect(result.body).toContain('"message":"An error has occurred."');
+    expect(result.body).toContain('"message":"There is a problem with the Funnelback search."');
     expect(result.body).toContain('"timestamp":');
 });
 
@@ -194,7 +194,7 @@ test("Response with 500 code returns an error", async () => {
     expect(result.statusCode).toBe(500);
     expect(result.body).toContain('"status":500');
     expect(result.body).toContain('"error":"Internal Server Error"');
-    expect(result.body).toContain('"message":"An error has occurred."');
+    expect(result.body).toContain('"message":"There is a problem with the Funnelback search."');
     expect(result.body).toContain('"timestamp":');
 });
 

--- a/src/utils/transformResponse.js
+++ b/src/utils/transformResponse.js
@@ -4,9 +4,21 @@
  */
 module.exports.transformResponse = (response) => {
     return response.map((course) => {
-        const transformedCourse = course;
-        transformDistanceLearning(transformedCourse);
-        transformDepartment(transformedCourse);
+        const actualCourse = () => {
+            if (course.department) {
+                return course;
+            }
+
+            console.log("Invalid course entry " + course.title);
+            return null;
+        };
+
+        const transformedCourse = actualCourse(course);
+        if (transformedCourse) {
+            transformDistanceLearning(transformedCourse);
+            transformDepartment(transformedCourse);
+        }
+
         return transformedCourse;
     });
 };

--- a/src/utils/transformResponse.js
+++ b/src/utils/transformResponse.js
@@ -4,25 +4,11 @@
  */
 module.exports.transformResponse = (response) => {
     return response.map((course) => {
-        if (isValid(course)) {
-            const transformedCourse = course;
-            transformDistanceLearning(transformedCourse);
-            transformDepartment(transformedCourse);
-
-            return transformedCourse;
-        }
-
-        return null;
+        const transformedCourse = course;
+        transformDistanceLearning(transformedCourse);
+        transformDepartment(transformedCourse);
+        return transformedCourse;
     });
-};
-
-const isValid = (course) => {
-    if (course.department) {
-        return true;
-    }
-
-    console.error("Invalid course entry " + course.title);
-    return false;
 };
 
 const transformDistanceLearning = (course) => {
@@ -50,6 +36,9 @@ const transformDepartment = (course) => {
         } else {
             course.department = [departments];
         }
+    } else {
+        course.department = [];
+        console.warn("Department missing for " + course.title);
     }
 
     return course;

--- a/src/utils/transformResponse.js
+++ b/src/utils/transformResponse.js
@@ -4,23 +4,25 @@
  */
 module.exports.transformResponse = (response) => {
     return response.map((course) => {
-        const actualCourse = () => {
-            if (course.department) {
-                return course;
-            }
-
-            console.log("Invalid course entry " + course.title);
-            return null;
-        };
-
-        const transformedCourse = actualCourse(course);
-        if (transformedCourse) {
+        if (isValid(course)) {
+            const transformedCourse = course;
             transformDistanceLearning(transformedCourse);
             transformDepartment(transformedCourse);
+
+            return transformedCourse;
         }
 
-        return transformedCourse;
+        return null;
     });
+};
+
+const isValid = (course) => {
+    if (course.department) {
+        return true;
+    }
+
+    console.error("Invalid course entry " + course.title);
+    return false;
 };
 
 const transformDistanceLearning = (course) => {

--- a/src/utils/transformResponse.js
+++ b/src/utils/transformResponse.js
@@ -38,7 +38,6 @@ const transformDepartment = (course) => {
         }
     } else {
         course.department = [];
-        console.warn("Department missing for " + course.title);
     }
 
     return course;

--- a/src/utils/transformResponse.test.js
+++ b/src/utils/transformResponse.test.js
@@ -27,8 +27,8 @@ describe("transformer", () => {
     });
 
     it("converts Yes and No to Booleans for distanceLearning", () => {
-        const negativeInput = [{ distanceLearning: "No" }];
-        const positiveInput = [{ distanceLearning: "Yes" }];
+        const negativeInput = [{ department: "Department", distanceLearning: "No" }];
+        const positiveInput = [{ department: "Department", distanceLearning: "Yes" }];
 
         expect(transformResponse(negativeInput)[0].distanceLearning).toBe(false);
         expect(transformResponse(positiveInput)[0].distanceLearning).toBe(true);
@@ -36,9 +36,9 @@ describe("transformer", () => {
 
     it("returns false for distanceLearning if the result is not expected", () => {
         const weirdInputs = [
-            { distanceLearning: "Maybe, maybe not" },
-            { distanceLearning: 53478 },
-            { distanceLearning: "I am distanceLearning" },
+            { department: "Department", distanceLearning: "Maybe, maybe not" },
+            { department: "Department", distanceLearning: 53478 },
+            { department: "Department", distanceLearning: "I am distanceLearning" },
         ];
 
         const result = transformResponse(weirdInputs);

--- a/src/utils/transformResponse.test.js
+++ b/src/utils/transformResponse.test.js
@@ -27,8 +27,8 @@ describe("transformer", () => {
     });
 
     it("converts Yes and No to Booleans for distanceLearning", () => {
-        const negativeInput = [{ department: "Department", distanceLearning: "No" }];
-        const positiveInput = [{ department: "Department", distanceLearning: "Yes" }];
+        const negativeInput = [{ distanceLearning: "No" }];
+        const positiveInput = [{ distanceLearning: "Yes" }];
 
         expect(transformResponse(negativeInput)[0].distanceLearning).toBe(false);
         expect(transformResponse(positiveInput)[0].distanceLearning).toBe(true);
@@ -36,9 +36,9 @@ describe("transformer", () => {
 
     it("returns false for distanceLearning if the result is not expected", () => {
         const weirdInputs = [
-            { department: "Department", distanceLearning: "Maybe, maybe not" },
-            { department: "Department", distanceLearning: 53478 },
-            { department: "Department", distanceLearning: "I am distanceLearning" },
+            { distanceLearning: "Maybe, maybe not" },
+            { distanceLearning: 53478 },
+            { distanceLearning: "I am distanceLearning" },
         ];
 
         const result = transformResponse(weirdInputs);
@@ -63,5 +63,11 @@ describe("transformer", () => {
         expect(transformResponse(singleDepartmentResponse)[0].department).toStrictEqual([
             "Department of Computer Science",
         ]);
+    });
+
+    it("returns an empty array if null department", () => {
+        const noDepartmentResponse = [{ department: null }];
+
+        expect(transformResponse(noDepartmentResponse)[0].department).toStrictEqual([]);
     });
 });


### PR DESCRIPTION
Did these both together because I needed to log my errors to be able to debug my logging of non-course entries. Though during the review, we came to the conclusion that 'non-course' entries, which we could only identify as results with missing meta data should not error or be logged, just returned with missing fields.