### PR TITLE
CFIN-319: Generate API using Serverless rather than OpenAPI spec

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -7,6 +7,7 @@ provider:
   # This role is required to deploy an application to AWS with an ESG Account. See https://wiki.york.ac.uk/display/AWS/AWS%3A+Github+Actions for details
   cfnRole: arn:aws:iam::${env:AWS_ACCOUNT_ID}:role/GithubActionsDeploymentRole
   region: eu-west-1
+  endpointType: REGIONAL
   stackTags:
     name: courses api
     group: ESG
@@ -25,6 +26,10 @@ package:
 functions:
   courses:
     handler: src/handler.courses
+    events:
+      - http:
+          path: courses
+          method: get
 
 custom:
   domainName: ${env:DOMAIN_NAME, ''}
@@ -38,35 +43,6 @@ resources:
         - ""
 
   Resources:
-    # The following would be done magically by Serverless if we were defining
-    # the API in the "normal" way, i.e., associating endpoints with functions
-    # in the "functions" section above. However, because we're using an
-    # OpenAPI specification to define our API, we lose the Serverless magic,
-    # and have to define a number of things ourselves in CloudFormation
-
-    # Create the API based on the OpenAPI specification
-    ApiGatewayRestApi:
-      Type: AWS::ApiGateway::RestApi
-      Properties:
-        Body: ${file(spec/openAPI.yml)}
-
-    # Deploy the API
-    ApiGatewayDeployment:
-      Type: AWS::ApiGateway::Deployment
-      Properties:
-        RestApiId:
-          Ref: ApiGatewayRestApi
-        StageName: ${self:provider.stage}
-
-    # Grant permission for the API to call the lambda - note that lambda name "courses"
-    # earlier in this file becomes "CoursesLambdaFunction" in CloudFormation
-    Permission:
-      Type: AWS::Lambda::Permission
-      Properties:
-        FunctionName: !GetAtt CoursesLambdaFunction.Arn
-        Action: lambda:InvokeFunction
-        Principal: apigateway.amazonaws.com
-
     # Setup the application's domain name as a custom domain name for API Gateway, then map it to the application's API
     ApiGatewayCustomDomainName:
       Type: AWS::ApiGateway::DomainName
@@ -81,7 +57,7 @@ resources:
     BasePathMapping:
       Type: AWS::ApiGateway::BasePathMapping
       Condition: UseCustomDomainName
-      DependsOn: [ApiGatewayDeployment]
+      DependsOn: ApiGatewayDeployment${sls:instanceId}
       Properties:
         BasePath: ""
         DomainName: !Ref ApiGatewayCustomDomainName

--- a/spec/openAPI.yml
+++ b/spec/openAPI.yml
@@ -53,18 +53,6 @@ paths:
           $ref: '#/components/responses/BadRequest'
         500:
           $ref: '#/components/responses/InternalServerError'
-      x-amazon-apigateway-integration:
-        uri:
-          Fn::Join:
-            - ''
-            - - 'arn:aws:apigateway:'
-              - Ref: AWS::Region
-              - ':lambda:path/2015-03-31/functions/'
-              - Fn::GetAtt: ["CoursesLambdaFunction", "Arn"]
-              - '/invocations'
-        passthroughBehavior: "when_no_match"
-        httpMethod: "POST" #This HAS to be POST for lambda integrations
-        type: "aws_proxy"
 components:
   responses:
     BadRequest:


### PR DESCRIPTION
This is another speculative PR - it's an alternative solution to CFIN-320.

The goal of this task is to ensure that tags are set correctly on API resources. The reason why they aren't is because of a bug (I believe) in CloudFormation that prevents tags from being set on APIs that use an OpenAPI specification to define them. This PR changes the API so that it is no longer defined by an OpenAPI specification - instead the API is generated by Serverless. This makes the application more closely resemble the examples in Serverless documentation

**Advantages of removing OpenAPI**

* Tags are applied as expected - no need for bash scripts or other workarounds
* Fewer custom CloudFormation resources to manage (simpler `serverless.yml`)
* Much easier to apply certain features to the API, like CORS support (just add `cors: true` in `serverless.yml`)
* OpenAPI specification no longer needs AWS specific configuration - it can be a "pure" specification document
* Serverless managed APIs get automatically re-deployed when you make a change to them
  * When you define the deployment yourself, as we are doing by using OpenAPI, API changes are not automatically redeployed - you would need to change the deployment resource's logical ID (in Cloudformation) to force a re-deployment 
  * We could work around this by changing the deployment resource's logical ID from `ApiGatewayDeployment` to `ApiGatewayDeployment${sls:instanceId}` - which is (I believe) how Serverless forces a re-deployment of the API every time

**Disadvantages of removing OpenAPI**

* API and specification are no longer defined by the one document - in principle they could diverge
* Request validation (which we currently don't do) is slightly simpler with OpenAPI
  * here's how to [turn on request validation using OpenAPI](https://github.com/university-of-york/uoy-api-courses/commit/3530ca53b6f271983798a24e850078dd959978e5)
  * although [it's not that much extra effort without OpenAPI](https://github.com/university-of-york/uoy-api-courses/commit/03b9cf27b26518471bbeeabead87801858c13e62)
  * as an aside, either way we should consider using request validation - it will prevent our Lambda being called unnecessarily

If API Gateway supported response validation then I would put that as a plus point for OpenAPI - but I haven't been able to find any documentation or examples of response validation working in API Gateway.

There might well be other advantages and disadvantages that I haven't listed. Would you prefer to use the OpenAPI spec to generate the API, or do you not think it is that important?