### PR TITLE
CFIN-288 Remove request validation from URLConstructor

### DIFF
--- a/src/errors/ClientError.js
+++ b/src/errors/ClientError.js
@@ -1,3 +1,0 @@
-class ClientError extends Error {}
-
-module.exports = ClientError;

--- a/src/handler.js
+++ b/src/handler.js
@@ -2,11 +2,14 @@
 const fetch = require("node-fetch");
 const { coursesUrl } = require("./utils/constructFunnelbackUrls");
 const { success, error } = require("./utils/format");
-const ClientError = require("./errors/ClientError");
 const { transformResponse } = require("./utils/transformResponse");
 
 module.exports.courses = async (event) => {
     try {
+        if (!event.queryStringParameters || !event.queryStringParameters.search) {
+            return error("The search parameter is required.", 400, "Bad Request", event.path);
+        }
+
         const url = coursesUrl(event.queryStringParameters);
 
         const searchResponse = await fetch(url, {
@@ -35,8 +38,6 @@ module.exports.courses = async (event) => {
     } catch (e) {
         console.error(e);
         switch (e.constructor.name) {
-            case ClientError.name:
-                return error(e.message, 400, "Bad Request", event.path);
             default:
                 return error("An error has occurred.", 500, "Internal Server Error", event.path);
         }

--- a/src/handler.js
+++ b/src/handler.js
@@ -6,11 +6,13 @@ const { transformResponse } = require("./utils/transformResponse");
 
 module.exports.courses = async (event) => {
     try {
-        if (!event.queryStringParameters || !event.queryStringParameters.search) {
+        const requestParams = event.queryStringParameters;
+
+        if (!requestParams || !requestParams.search) {
             return error("The search parameter is required.", 400, "Bad Request", event.path);
         }
 
-        const url = coursesUrl(event.queryStringParameters);
+        const url = coursesUrl(requestParams);
 
         const searchResponse = await fetch(url, {
             method: "GET",
@@ -37,9 +39,6 @@ module.exports.courses = async (event) => {
         return success({ results });
     } catch (e) {
         console.error(e);
-        switch (e.constructor.name) {
-            default:
-                return error("An error has occurred.", 500, "Internal Server Error", event.path);
-        }
+        return error("An error has occurred.", 500, "Internal Server Error", event.path);
     }
 };

--- a/src/utils/constructFunnelbackUrls.js
+++ b/src/utils/constructFunnelbackUrls.js
@@ -1,19 +1,17 @@
 const { URLSearchParams } = require("url");
-const ClientError = require("../errors/ClientError");
 const { BASE_URL, COLLECTION, FORM, PROFILE, SMETA_CONTENT_TYPE } = require("../constants/UrlAndParameters");
 
 module.exports.coursesUrl = (parameters) => {
-    if (!parameters || !parameters.search) {
-        throw new ClientError("The search parameter is required.");
-    }
-
     const queryParams = new URLSearchParams();
 
     queryParams.append("collection", COLLECTION);
     queryParams.append("form", FORM);
     queryParams.append("profile", PROFILE);
     queryParams.append("smeta_contentType", SMETA_CONTENT_TYPE);
-    queryParams.append("query", parameters.search);
+
+    if (parameters.search) {
+        queryParams.append("query", parameters.search);
+    }
 
     if (parameters.max) {
         queryParams.append("num_ranks", parameters.max);

--- a/src/utils/constructFunnelbackUrls.test.js
+++ b/src/utils/constructFunnelbackUrls.test.js
@@ -1,34 +1,13 @@
 const { coursesUrl } = require("./constructFunnelbackUrls");
-const ClientError = require("../errors/ClientError");
 const { BASE_URL, COLLECTION, FORM, PROFILE, SMETA_CONTENT_TYPE } = require("../constants/UrlAndParameters");
 
 const constantPartOfSearchUrl = `${BASE_URL}?collection=${COLLECTION}&form=${FORM}&profile=${PROFILE}&smeta_contentType=${SMETA_CONTENT_TYPE}`;
 
-test("Call without parameters throws ClientError", async () => {
-    expect(() => {
-        coursesUrl();
-    }).toThrow(ClientError);
-
-    expect(() => {
-        coursesUrl();
-    }).toThrow("The search parameter is required.");
+test("No search parameters gives a blank search", () => {
+    expect(coursesUrl({})).toEqual(constantPartOfSearchUrl);
 });
 
-test("Call without search parameter throws ClientError", async () => {
-    const parameters = {
-        max: 5,
-    };
-
-    expect(() => {
-        coursesUrl(parameters);
-    }).toThrow(ClientError);
-
-    expect(() => {
-        coursesUrl(parameters);
-    }).toThrow("The search parameter is required.");
-});
-
-test("Call with search parameter returns correct URL", async () => {
+test("Call with search parameter returns correct URL", () => {
     const parameters = {
         search: "Maths",
     };
@@ -38,7 +17,7 @@ test("Call with search parameter returns correct URL", async () => {
     expect(coursesUrl(parameters)).toEqual(expectedUrl);
 });
 
-test("Call with search & max parameters returns correct URL", async () => {
+test("Call with search & max parameters returns correct URL", () => {
     const parameters = {
         search: "Maths",
         max: 12,
@@ -49,7 +28,7 @@ test("Call with search & max parameters returns correct URL", async () => {
     expect(coursesUrl(parameters)).toEqual(expectedUrl);
 });
 
-test("Call with search & offset parameters returns correct URL", async () => {
+test("Call with search & offset parameters returns correct URL", () => {
     const parameters = {
         search: "Maths",
         offset: 25,
@@ -60,7 +39,7 @@ test("Call with search & offset parameters returns correct URL", async () => {
     expect(coursesUrl(parameters)).toEqual(expectedUrl);
 });
 
-test("Call with search, max & offset parameters returns correct URL", async () => {
+test("Call with search, max & offset parameters returns correct URL", () => {
     const parameters = {
         search: "Maths",
         max: 18,


### PR DESCRIPTION
This is the simplest example approach to removing the validation code from the utility function that constructs URLs.

I think there's a lot to talk about here relating to how we want to develop the API and which (if any) code quality standards we want to uphold. We currently don't have any form of type validation, for example. I'll put more in depth comments on the code itself.