### PR TITLE
Add a github workflow to report on the package size

### DIFF
--- a/.github/workflows/report-package-size.yml
+++ b/.github/workflows/report-package-size.yml
@@ -1,0 +1,21 @@
+name: Report Package Size
+
+on: [pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the application's source code
+        uses: actions/checkout@v2
+
+      - name: Check and report changes in the application's package size
+        uses: preactjs/compressed-size-action@e2bfc4b346d78f9a3c7e8a2e22bcbd285a25fafa
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          build-script: package
+          pattern: .serverless/*.zip
+          compression: none
+          minimum-change-threshold: 1024
+        env:
+          AWS_ACCOUNT_ID: ${{ secrets.DEV_AWS_ACCOUNT_ID }}

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "xo .",
     "formatandcheck": "npm run format && npm run lint && npm run test",
     "check": "npm run checkformat && npm run lint && npm run test",
+    "package": "serverless package",
     "deploy": "serverless deploy",
     "undeploy": "serverless remove"
   },


### PR DESCRIPTION
This adds the "report package size" workflow which was recently [added to the Course Search repo](https://github.com/university-of-york/uoy-app-course-search/pull/71).