### PR TITLE
CFIN-416 Reduce build package size by excluding unneeded items

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -19,8 +19,17 @@ provider:
 
 package:
   exclude:
+    - .github/**
+    - .idea/**
     - docs/**
     - spec/**
+    - package-lock.json
+    - package.json
+    - .prettierignore
+    - .prettierrc.json
+    - .xo-config.json
+    - LICENSE
+    - README.md
 
 functions:
   courses:


### PR DESCRIPTION
These files aren't needed in the build package deployed by serverless. Removing them reduces the package size from about 215 kB to about 65 kB.