### PR TITLE
CFIN-471 Allow different Funnelback profiles to be queried per environment

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,5 @@
+BASE_URL=https://www.york.ac.uk/search/
+COLLECTION=york-uni-courses
+FORM=course-search
+PROFILE=_default_preview
+SMETA_CONTENT_TYPE=course

--- a/.env.production
+++ b/.env.production
@@ -1,0 +1,5 @@
+BASE_URL=https://www.york.ac.uk/search/
+COLLECTION=york-uni-courses
+FORM=course-search
+PROFILE=_default
+SMETA_CONTENT_TYPE=course

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,5 @@
+BASE_URL=https://www.york.ac.uk/search/
+COLLECTION=york-uni-courses
+FORM=course-search
+PROFILE=_default_preview
+SMETA_CONTENT_TYPE=course

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Deploy - dev
         if: github.ref == 'refs/heads/dev'
-        run: npm run deploy
+        run: npm run deploy:dev
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -3857,6 +3857,12 @@
       "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==",
       "dev": true
     },
+    "dotenv-expand": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
+      "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA==",
+      "dev": true
+    },
     "download": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/download/-/download-8.0.0.tgz",
@@ -10419,6 +10425,17 @@
           "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
           "dev": true
         }
+      }
+    },
+    "serverless-dotenv-plugin": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/serverless-dotenv-plugin/-/serverless-dotenv-plugin-3.8.1.tgz",
+      "integrity": "sha512-v3JqGogpa+z+WpK7Esbjnnm7DzLh3t1aGafXr/SvQqFyl7HDtLkXfEzb18henyPi0Sn8Kv3VtOMnHlLvpip5tw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "dotenv": "^8.2.0",
+        "dotenv-expand": "^5.1.0"
       }
     },
     "set-blocking": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "license": "MIT",
   "devDependencies": {
     "ajv": "^7.0.3",
+    "dotenv": "^8.2.0",
     "jest": "^26.4.2",
     "jest-fetch-mock": "^3.0.3",
     "prettier": "2.1.2",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "jest-fetch-mock": "^3.0.3",
     "prettier": "2.1.2",
     "serverless": "^2.18.0",
+    "serverless-dotenv-plugin": "^3.1.0",
     "xo": "^0.33.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "lint": "xo .",
     "formatandcheck": "npm run format && npm run lint && npm run test",
     "check": "npm run checkformat && npm run lint && npm run test",
-    "package": "serverless package",
-    "deploy": "serverless deploy",
+    "package": "serverless package --env production",
+    "deploy": "serverless deploy --env production",
+    "deploy:dev": "serverless deploy --env development",
     "undeploy": "serverless remove"
   },
   "keywords": [],

--- a/serverless.yml
+++ b/serverless.yml
@@ -35,6 +35,9 @@ functions:
   courses:
     handler: src/handler.courses
 
+plugins:
+  - serverless-dotenv-plugin
+
 custom:
   domainName: ${env:DOMAIN_NAME, ''}
   sslCertificateArn: ${env:SSL_CERTIFICATE_ARN, ''}

--- a/src/constants/UrlAndParameters.js
+++ b/src/constants/UrlAndParameters.js
@@ -1,9 +1,0 @@
-const URL_AND_PARAMETERS = {
-    BASE_URL: "https://www.york.ac.uk/search/",
-    COLLECTION: "york-uni-courses",
-    FORM: "course-search",
-    PROFILE: "_default_preview",
-    SMETA_CONTENT_TYPE: "course",
-};
-
-module.exports = URL_AND_PARAMETERS;

--- a/src/handler.test.js
+++ b/src/handler.test.js
@@ -1,11 +1,28 @@
 const { courses } = require("./handler");
 const fetch = require("jest-fetch-mock");
-const { BASE_URL, COLLECTION, FORM, PROFILE, SMETA_CONTENT_TYPE } = require("./constants/UrlAndParameters");
 
-const constantPartOfSearchUrl = `${BASE_URL}?collection=${COLLECTION}&form=${FORM}&profile=${PROFILE}&smeta_contentType=${SMETA_CONTENT_TYPE}`;
+const constantPartOfSearchUrl = `${process.env.BASE_URL}?collection=${process.env.COLLECTION}&form=${process.env.FORM}&profile=${process.env.PROFILE}&smeta_contentType=${process.env.SMETA_CONTENT_TYPE}`;
 
 beforeEach(() => {
     fetch.resetMocks();
+});
+
+test("constructs the Funnelback url with the expected environment variables", async () => {
+
+    const event = {
+        queryStringParameters: {
+            search: "maths",
+        },
+    };
+
+    fetch.mockResponse(JSON.stringify({ results: [] }));
+
+    await courses(event);
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    const calledUrl = fetch.mock.calls[0][0];
+    expect(calledUrl).toMatch(/^https:\/\/www.york.ac.uk\/search\/\?collection=york-uni-courses&form=course-search&profile=_default_preview&smeta_contentType=course.+/);
 });
 
 test("Simple query calls Funnelback", async () => {

--- a/src/handler.test.js
+++ b/src/handler.test.js
@@ -7,24 +7,6 @@ beforeEach(() => {
     fetch.resetMocks();
 });
 
-test("constructs the Funnelback url with the expected environment variables", async () => {
-
-    const event = {
-        queryStringParameters: {
-            search: "maths",
-        },
-    };
-
-    fetch.mockResponse(JSON.stringify({ results: [] }));
-
-    await courses(event);
-
-    expect(fetch).toHaveBeenCalledTimes(1);
-
-    const calledUrl = fetch.mock.calls[0][0];
-    expect(calledUrl).toMatch(/^https:\/\/www.york.ac.uk\/search\/\?collection=york-uni-courses&form=course-search&profile=_default_preview&smeta_contentType=course.+/);
-});
-
 test("Simple query calls Funnelback", async () => {
     const event = {
         queryStringParameters: {

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,1 +1,5 @@
 global.fetch = require("jest-fetch-mock").enableMocks();
+
+require("dotenv").config({
+    path: ".env.test",
+});

--- a/src/utils/constructFunnelbackUrls.js
+++ b/src/utils/constructFunnelbackUrls.js
@@ -1,13 +1,12 @@
 const { URLSearchParams } = require("url");
-const { BASE_URL, COLLECTION, FORM, PROFILE, SMETA_CONTENT_TYPE } = require("../constants/UrlAndParameters");
 
 module.exports.coursesUrl = (parameters) => {
     const queryParams = new URLSearchParams();
 
-    queryParams.append("collection", COLLECTION);
-    queryParams.append("form", FORM);
-    queryParams.append("profile", PROFILE);
-    queryParams.append("smeta_contentType", SMETA_CONTENT_TYPE);
+    queryParams.append("collection", process.env.COLLECTION);
+    queryParams.append("form", process.env.FORM);
+    queryParams.append("profile", process.env.PROFILE);
+    queryParams.append("smeta_contentType", process.env.SMETA_CONTENT_TYPE);
 
     if (parameters.search) {
         queryParams.append("query", parameters.search);
@@ -21,5 +20,5 @@ module.exports.coursesUrl = (parameters) => {
         queryParams.append("start_rank", parameters.offset);
     }
 
-    return `${BASE_URL}?${queryParams.toString()}`;
+    return `${process.env.BASE_URL}?${queryParams.toString()}`;
 };

--- a/src/utils/constructFunnelbackUrls.test.js
+++ b/src/utils/constructFunnelbackUrls.test.js
@@ -2,7 +2,7 @@ const { coursesUrl } = require("./constructFunnelbackUrls");
 
 const constantPartOfSearchUrl = `${process.env.BASE_URL}?collection=${process.env.COLLECTION}&form=${process.env.FORM}&profile=${process.env.PROFILE}&smeta_contentType=${process.env.SMETA_CONTENT_TYPE}`;
 
-test("constructs the Funnelback url with the expected environment variables", async () => {
+test("constructs the Funnelback url with the expected environment variables", () => {
     expect(coursesUrl({})).toEqual(
         "https://www.york.ac.uk/search/?collection=york-uni-courses&form=course-search&profile=_default_preview&smeta_contentType=course"
     );

--- a/src/utils/constructFunnelbackUrls.test.js
+++ b/src/utils/constructFunnelbackUrls.test.js
@@ -1,7 +1,11 @@
 const { coursesUrl } = require("./constructFunnelbackUrls");
-const { BASE_URL, COLLECTION, FORM, PROFILE, SMETA_CONTENT_TYPE } = require("../constants/UrlAndParameters");
 
-const constantPartOfSearchUrl = `${BASE_URL}?collection=${COLLECTION}&form=${FORM}&profile=${PROFILE}&smeta_contentType=${SMETA_CONTENT_TYPE}`;
+const constantPartOfSearchUrl = `${process.env.BASE_URL}?collection=${process.env.COLLECTION}&form=${process.env.FORM}&profile=${process.env.PROFILE}&smeta_contentType=${process.env.SMETA_CONTENT_TYPE}`;
+
+test("constructs the Funnelback url with the expected environment variables", async () => {
+
+    expect(coursesUrl({})).toEqual("https://www.york.ac.uk/search/?collection=york-uni-courses&form=course-search&profile=_default_preview&smeta_contentType=course")
+});
 
 test("No search parameters gives a blank search", () => {
     expect(coursesUrl({})).toEqual(constantPartOfSearchUrl);

--- a/src/utils/constructFunnelbackUrls.test.js
+++ b/src/utils/constructFunnelbackUrls.test.js
@@ -3,8 +3,9 @@ const { coursesUrl } = require("./constructFunnelbackUrls");
 const constantPartOfSearchUrl = `${process.env.BASE_URL}?collection=${process.env.COLLECTION}&form=${process.env.FORM}&profile=${process.env.PROFILE}&smeta_contentType=${process.env.SMETA_CONTENT_TYPE}`;
 
 test("constructs the Funnelback url with the expected environment variables", async () => {
-
-    expect(coursesUrl({})).toEqual("https://www.york.ac.uk/search/?collection=york-uni-courses&form=course-search&profile=_default_preview&smeta_contentType=course")
+    expect(coursesUrl({})).toEqual(
+        "https://www.york.ac.uk/search/?collection=york-uni-courses&form=course-search&profile=_default_preview&smeta_contentType=course"
+    );
 });
 
 test("No search parameters gives a blank search", () => {


### PR DESCRIPTION
This PR changes the API to query the `_default` Funnelback profile in the live environment, and the `default_preview` profile in development.