### PR TITLE
CFIN-470 Update the API to query the courses meta-collection instead of york-uni-courses

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
 BASE_URL=https://www.york.ac.uk/search/
-COLLECTION=york-uni-courses
+COLLECTION=courses
 FORM=course-search
 PROFILE=_default_preview
 SMETA_CONTENT_TYPE=course

--- a/.env.production
+++ b/.env.production
@@ -1,5 +1,5 @@
 BASE_URL=https://www.york.ac.uk/search/
-COLLECTION=york-uni-courses
+COLLECTION=courses
 FORM=course-search
 PROFILE=_default
 SMETA_CONTENT_TYPE=course

--- a/.env.test
+++ b/.env.test
@@ -1,5 +1,5 @@
 BASE_URL=https://www.york.ac.uk/search/
-COLLECTION=york-uni-courses
+COLLECTION=courses
 FORM=course-search
 PROFILE=_default_preview
 SMETA_CONTENT_TYPE=course

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "checkformat": "prettier --check .",
     "lint": "xo .",
     "formatandcheck": "npm run format && npm run lint && npm run test",
+    "fc": "npm run formatandcheck",
     "check": "npm run checkformat && npm run lint && npm run test",
     "package": "serverless package --env production",
     "deploy": "serverless deploy --env production",

--- a/src/utils/constructFunnelbackUrls.test.js
+++ b/src/utils/constructFunnelbackUrls.test.js
@@ -4,7 +4,7 @@ const constantPartOfSearchUrl = `${process.env.BASE_URL}?collection=${process.en
 
 test("constructs the Funnelback url with the expected environment variables", async () => {
     expect(coursesUrl({})).toEqual(
-        "https://www.york.ac.uk/search/?collection=york-uni-courses&form=course-search&profile=_default_preview&smeta_contentType=course"
+        "https://www.york.ac.uk/search/?collection=courses&form=course-search&profile=_default_preview&smeta_contentType=course"
     );
 });
 


### PR DESCRIPTION
Added the `npm run fc` shorthand command while I'm here