### PR TITLE
Query Funnelback directly rather than via www.york.ac.uk

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
-BASE_URL=https://www.york.ac.uk/search/
+BASE_URL=https://york.funnelback.co.uk/search/
 COLLECTION=courses
 FORM=course-search
 PROFILE=_default_preview

--- a/.env.production
+++ b/.env.production
@@ -1,4 +1,4 @@
-BASE_URL=https://www.york.ac.uk/search/
+BASE_URL=https://york.funnelback.co.uk/search/
 COLLECTION=courses
 FORM=course-search
 PROFILE=_default


### PR DESCRIPTION
Up until now, the Courses API has sent search requests to Funnelback using the URL `https://www.york.ac.uk/search`. `https://www.york.ac.uk/search` passes these requests on to `https://york.funnelback.co.uk/search`. This pull request modifies the Courses API to send search requests directly to `https://york.funnelback.co.uk/search`. 

There is no advantage to having these requests flow through `www.york.ac.uk` on their way to Funnelback. For user searches of the University website, the advantage of using `www.york.ac.uk/search` is that if Funnelback is down then they are switched over to using Google, and although the user experience might be a little clunky, the user gets their search results. This switching feature is of no use to the Courses API - Google is not going to provide search results in the expected format.

The main downsides of using `www.york.ac.uk/search` are:
- an unnecessary network performance hit having each search go via York on its way to Funnelback
- intermittent 502/503 errors from `www.york.ac.uk` on occasions when Funnelback is slow to respond

I have [deployed this change to my sandbox](https://pma5tlnoq8.execute-api.eu-west-1.amazonaws.com/v1/courses?search=physics), tested it out, and it seems to work exactly as before.