### PR TITLE
CFIN-586: Match log format

### DIFF
--- a/src/constants/constants.js
+++ b/src/constants/constants.js
@@ -1,12 +1,7 @@
-const LOG_TYPES = {
-    APPLICATION: "application",
-    AUDIT: "audit",
-};
-
 const HTTP_CODES = {
     OK: 200,
     BAD_REQUEST: 400,
     INTERNAL_SERVER_ERROR: 500,
 };
 
-module.exports = { LOG_TYPES, HTTP_CODES };
+module.exports = { HTTP_CODES };

--- a/src/constants/errors.js
+++ b/src/constants/errors.js
@@ -1,7 +1,7 @@
 class NoQueryGivenError extends Error {
     constructor(message, details) {
         super(message);
-        this.name = "NoQueryGivenError";
+        this.type = "NoQueryGivenError";
         this.details = details;
     }
 }
@@ -9,7 +9,7 @@ class NoQueryGivenError extends Error {
 class FunnelbackError extends Error {
     constructor(message, details) {
         super(message);
-        this.name = "FunnelbackError";
+        this.type = "FunnelbackError";
         this.details = details;
     }
 }

--- a/src/handler.js
+++ b/src/handler.js
@@ -60,7 +60,7 @@ module.exports.courses = async (event) => {
 
         if (err.type === "NoQueryGivenError") {
             // User error, only an info severity
-            logger.info(logEntry(event, null, err));
+            logger.info(logEntry(event, null, err), "No query given");
         } else {
             // Server error, error severity
             logger.error(logEntry(event, null, err), "Internal Server Error");

--- a/src/handler.js
+++ b/src/handler.js
@@ -65,6 +65,7 @@ module.exports.courses = async (event) => {
             // Server error, error severity
             logger.error(logEntry(event, null, err), "Internal Server Error");
         }
+
         return error(err.message, err.details.status, err.details.statusText, event.path);
     }
 };

--- a/src/handler.js
+++ b/src/handler.js
@@ -63,7 +63,7 @@ module.exports.courses = async (event) => {
             logger.info(logEntry(event, null, err), "No query given");
         } else {
             // Server error, error severity
-            logger.error(logEntry(event, null, err), "Internal Server Error");
+            logger.error(logEntry(event, null, err), err.message);
         }
 
         return error(err.message, err.details.status, err.details.statusText, event.path);

--- a/src/handler.js
+++ b/src/handler.js
@@ -1,11 +1,11 @@
 ("use strict");
 const fetch = require("node-fetch");
 const { coursesUrl } = require("./utils/constructFunnelbackUrls");
-const { logEntry, errorEntry } = require("./utils/logEntry");
+const { logEntry } = require("./utils/logEntry");
 const { success, error } = require("./utils/format");
 const { transformResponse } = require("./utils/transformResponse");
 const { overrideUrls } = require("./utils/overrideUrls");
-const { LOG_TYPES, HTTP_CODES } = require("./constants/constants");
+const { HTTP_CODES } = require("./constants/constants");
 const { logger } = require("./utils/logger");
 const { NoQueryGivenError, FunnelbackError } = require("./constants/errors");
 
@@ -14,12 +14,13 @@ module.exports.courses = async (event) => {
         const requestParams = event.queryStringParameters;
 
         if (!requestParams || !requestParams.search) {
-            const errDetails = {
+            const errorDetails = {
+                funnelBackUrl: null,
                 status: HTTP_CODES.BAD_REQUEST,
                 statusText: "Bad Request",
             };
-            const err = new NoQueryGivenError("The search parameter is required.", errDetails);
-            logger.info(errorEntry(event, err, null));
+            const err = new NoQueryGivenError("The search parameter is required.", errorDetails);
+            logger.info(logEntry(event, null, err));
             return error(err.message, err.details.status, err.details.statusText, event.path);
         }
 
@@ -46,20 +47,24 @@ module.exports.courses = async (event) => {
         let results = transformResponse(body.results);
         results = overrideUrls(results);
 
-        const additionalDetails = { numberOfMatches };
-        logger.info(logEntry(event, searchResponse.status, LOG_TYPES.AUDIT, additionalDetails));
+        logger.info(logEntry(event, { numberOfMatches, statusCode: searchResponse.status }));
 
         return success({ numberOfMatches, results });
     } catch (err) {
-        if (!err.details) {
+        // When there is an unknown error it is likely there is no error details passed, so
+        // we are initialising an empty error details
+        if (!err.details)
             err.details = {
                 funnelBackUrl: null,
                 status: HTTP_CODES.INTERNAL_SERVER_ERROR,
                 statusText: "Internal Server Error",
             };
-        }
 
-        logger.error(errorEntry(event, err, null));
+        if (!err.type) err.type = err.name || "UnknownError";
+
+        if (!err.message) err.message = "Internal Server Error";
+
+        logger.error(logEntry(event, null, err), "Internal Server Error");
         return error(err.message, err.details.status, err.details.statusText, event.path);
     }
 };

--- a/src/handler.js
+++ b/src/handler.js
@@ -45,7 +45,7 @@ module.exports.courses = async (event) => {
         let results = transformResponse(body.results);
         results = overrideUrls(results);
 
-        logger.info(logEntry(event, { numberOfMatches, statusCode: searchResponse.status }));
+        logger.info(logEntry(event, { numberOfMatches, statusCode: searchResponse.status }), "Course search conducted");
 
         return success({ numberOfMatches, results });
     } catch (err) {

--- a/src/handler.js
+++ b/src/handler.js
@@ -19,9 +19,7 @@ module.exports.courses = async (event) => {
                 status: HTTP_CODES.BAD_REQUEST,
                 statusText: "Bad Request",
             };
-            const err = new NoQueryGivenError("The search parameter is required.", errorDetails);
-            logger.info(logEntry(event, null, err));
-            return error(err.message, err.details.status, err.details.statusText, event.path);
+            throw new NoQueryGivenError("The search parameter is required.", errorDetails);
         }
 
         const url = coursesUrl(requestParams);
@@ -60,11 +58,13 @@ module.exports.courses = async (event) => {
                 statusText: "Internal Server Error",
             };
 
-        if (!err.type) err.type = err.name || "UnknownError";
-
-        if (!err.message) err.message = "Internal Server Error";
-
-        logger.error(logEntry(event, null, err), "Internal Server Error");
+        if (err.type === "NoQueryGivenError") {
+            // User error, only an info severity
+            logger.info(logEntry(event, null, err));
+        } else {
+            // Server error, error severity
+            logger.error(logEntry(event, null, err), "Internal Server Error");
+        }
         return error(err.message, err.details.status, err.details.statusText, event.path);
     }
 };

--- a/src/handler.test.js
+++ b/src/handler.test.js
@@ -524,7 +524,7 @@ describe("Logger output", () => {
             null,
             new FunnelbackError("There is a problem with the Funnelback search.")
         );
-        expect(logger.error).toBeCalledWith(mockEntry, "Internal Server Error");
+        expect(logger.error).toBeCalledWith(mockEntry, "There is a problem with the Funnelback search.");
     });
 
     it("logs an error when catching malformed JSON", async () => {
@@ -546,6 +546,9 @@ describe("Logger output", () => {
             null,
             new Error("invalid json response body at  reason: Unexpected end of JSON input")
         );
-        expect(logger.error).toBeCalledWith(mockEntry, "Internal Server Error");
+        expect(logger.error).toBeCalledWith(
+            mockEntry,
+            "invalid json response body at  reason: Unexpected end of JSON input"
+        );
     });
 });

--- a/src/handler.test.js
+++ b/src/handler.test.js
@@ -480,7 +480,7 @@ describe("Logger output", () => {
             { queryStringParameters: { search: "physics" } },
             { statusCode: 200, numberOfMatches: undefined }
         );
-        expect(logger.info).toBeCalledWith({ foo: "bar" });
+        expect(logger.info).toBeCalledWith({ foo: "bar" }, "Course search conducted");
     });
 
     it("logs a single info if there are no search parameters given", async () => {

--- a/src/handler.test.js
+++ b/src/handler.test.js
@@ -499,7 +499,7 @@ describe("Logger output", () => {
             null,
             new NoQueryGivenError("The search parameter is required.")
         );
-        expect(logger.info).toBeCalledWith(mockEntry);
+        expect(logger.info).toBeCalledWith(mockEntry, "No query given");
     });
 
     it("logs a single error when there is a funnelback problem", async () => {

--- a/src/handler.test.js
+++ b/src/handler.test.js
@@ -1,8 +1,8 @@
 const { courses } = require("./handler");
-const { HTTP_CODES } = require("./constants/constants.js");
+const { HTTP_CODES } = require("./constants/constants");
 const fetch = require("jest-fetch-mock");
 const { logger } = require("./utils/logger");
-const { logEntry, errorEntry } = require("./utils/logEntry");
+const { logEntry } = require("./utils/logEntry");
 const { NoQueryGivenError, FunnelbackError } = require("./constants/errors");
 
 jest.mock("./utils/logger");
@@ -10,12 +10,20 @@ jest.mock("./utils/logEntry");
 
 const constantPartOfSearchUrl = `${process.env.BASE_URL}?collection=${process.env.COLLECTION}&form=${process.env.FORM}&profile=${process.env.PROFILE}&smeta_contentType=${process.env.SMETA_CONTENT_TYPE}`;
 
+const mockEntry = {
+    details: { clientIp: "144.32.100.16", parameters: { foo: "bar" }, statusCode: 418 },
+    error: {
+        details: {
+            foo: "bar",
+        },
+    },
+};
+
 beforeEach(() => {
     fetch.resetMocks();
     logger.info.mockReset();
     logger.error.mockReset();
     logEntry.mockReset();
-    errorEntry.mockReset();
 });
 
 test("Simple query calls Funnelback", async () => {
@@ -386,6 +394,7 @@ test("Response with malformed JSON returns an error", async () => {
     };
 
     fetch.mockResponse('{"results": [', { status: HTTP_CODES.OK });
+    logEntry.mockReturnValue(mockEntry);
 
     const result = await courses(event);
 
@@ -467,9 +476,10 @@ describe("Logger output", () => {
 
         expect(logger.error).toBeCalledTimes(0);
         expect(logger.info).toBeCalledTimes(1);
-        expect(logEntry).toBeCalledWith({ queryStringParameters: { search: "physics" } }, 200, "audit", {
-            numberOfMatches: undefined,
-        });
+        expect(logEntry).toBeCalledWith(
+            { queryStringParameters: { search: "physics" } },
+            { statusCode: 200, numberOfMatches: undefined }
+        );
         expect(logger.info).toBeCalledWith({ foo: "bar" });
     });
 
@@ -478,18 +488,18 @@ describe("Logger output", () => {
             queryStringParameters: {},
         };
 
-        errorEntry.mockReturnValue({ foo: "bar" });
+        logEntry.mockReturnValue(mockEntry);
 
         await courses(event);
 
         expect(logger.error).toBeCalledTimes(0);
         expect(logger.info).toBeCalledTimes(1);
-        expect(errorEntry).toBeCalledWith(
+        expect(logEntry).toBeCalledWith(
             { queryStringParameters: {} },
-            new NoQueryGivenError("The search parameter is required."),
-            null
+            null,
+            new NoQueryGivenError("The search parameter is required.")
         );
-        expect(logger.info).toBeCalledWith({ foo: "bar" });
+        expect(logger.info).toBeCalledWith(mockEntry);
     });
 
     it("logs a single error when there is a funnelback problem", async () => {
@@ -503,18 +513,18 @@ describe("Logger output", () => {
             status: HTTP_CODES.BAD_REQUEST,
             statusText: "Bad Request",
         });
-        errorEntry.mockReturnValue({ foo: "bar" });
+        logEntry.mockReturnValue(mockEntry);
 
         await courses(event);
 
         expect(logger.error).toBeCalledTimes(1);
         expect(logger.info).toBeCalledTimes(0);
-        expect(errorEntry).toBeCalledWith(
+        expect(logEntry).toBeCalledWith(
             { queryStringParameters: { search: "physics" } },
-            new FunnelbackError("There is a problem with the Funnelback search."),
-            null
+            null,
+            new FunnelbackError("There is a problem with the Funnelback search.")
         );
-        expect(logger.error).toBeCalledWith({ foo: "bar" });
+        expect(logger.error).toBeCalledWith(mockEntry, "Internal Server Error");
     });
 
     it("logs an error when catching malformed JSON", async () => {
@@ -525,17 +535,17 @@ describe("Logger output", () => {
         };
 
         fetch.mockResponse('{"results": [', { status: HTTP_CODES.OK });
-        errorEntry.mockReturnValue({ foo: "bar" });
+        logEntry.mockReturnValue(mockEntry);
 
         await courses(event);
 
         expect(logger.error).toBeCalledTimes(1);
         expect(logger.info).toBeCalledTimes(0);
-        expect(errorEntry).toBeCalledWith(
+        expect(logEntry).toBeCalledWith(
             { queryStringParameters: { search: "physics" } },
-            new Error("invalid json response body at  reason: Unexpected end of JSON input"),
-            null
+            null,
+            new Error("invalid json response body at  reason: Unexpected end of JSON input")
         );
-        expect(logger.error).toBeCalledWith({ foo: "bar" });
+        expect(logger.error).toBeCalledWith(mockEntry, "Internal Server Error");
     });
 });

--- a/src/integrationTests/logger.integration.test.js
+++ b/src/integrationTests/logger.integration.test.js
@@ -10,35 +10,6 @@ describe("Logger", () => {
         expect(res).toEqual(expect.anything());
         expect(() => JSON.parse(res)).not.toThrow();
     });
-    it("has IP fields", async () => {
-        const res = await invokeDemoLoggerGetResult();
-        const resJSON = JSON.parse(res);
-        expect(resJSON["ip.client"]).toBeDefined();
-        expect(resJSON["ip.source"]).toBeDefined();
-        expect(resJSON["ip.sourcePort"]).toBeDefined();
-    });
-    it("has request fields", async () => {
-        const res = await invokeDemoLoggerGetResult();
-        const resJSON = JSON.parse(res);
-        expect(resJSON["req.user"]).toBeDefined();
-        expect(resJSON["req.service"]).toEqual("uoy-app-course-search");
-    });
-    it("has self fields", async () => {
-        const res = await invokeDemoLoggerGetResult();
-        const resJSON = JSON.parse(res);
-        expect(resJSON["self.application"]).toEqual("uoy-api-courses");
-        expect(resJSON["self.type"]).toBeDefined();
-        expect(resJSON["self.statusCode"]).toBeDefined();
-        expect(resJSON["self.version"]).toEqual("v1");
-    });
-    it("has miscellaneous fields", async () => {
-        const res = await invokeDemoLoggerGetResult();
-        const resJSON = JSON.parse(res);
-        expect(resJSON.correlationId).toBeDefined();
-        expect(resJSON.sensitive).toBeDefined();
-        expect(resJSON.schemaURI).toEqual("https://university-of-york.github.io/uoy-api-courses/");
-        expect(resJSON.type).toBeDefined();
-    });
     it("has output level as a string", async () => {
         const res = await invokeDemoLoggerGetResult();
         const resJSON = JSON.parse(res);

--- a/src/utils/logEntry.js
+++ b/src/utils/logEntry.js
@@ -16,6 +16,7 @@ const logEntry = (event, details, error) => {
             entry.details.statusCode = error.details.status;
             entry.details.statusText = error.details.statusText;
         }
+        if (!entry.error.type) entry.error.type = entry.error.name;
     }
 
     return entry;

--- a/src/utils/logEntry.js
+++ b/src/utils/logEntry.js
@@ -1,48 +1,24 @@
-const { LOG_TYPES } = require("../constants/constants");
-
-const logEntry = (event, statuscode, logType, additionalDetails) => {
-    const getHeaderInfo = () => {
-        const requestHeaders = event?.headers;
-
-        const source = requestHeaders ? requestHeaders["X-Forwarded-For"] : null;
-        const sourcePort = requestHeaders ? requestHeaders["X-Forwarded-Port"] : null;
-        return {
-            source,
-            sourcePort,
-        };
+const logEntry = (event, details, error) => {
+    const entry = {
+        details,
     };
 
-    const headers = getHeaderInfo();
+    if (!entry.details) entry.details = {};
 
-    return {
-        "ip.client": event?.requestContext?.identity?.sourceIp || null,
-        "ip.source": headers.source || null,
-        "ip.sourcePort": headers.sourcePort || null,
-        correlationId: event?.requestContext?.apiId || null,
-        "self.type": event?.httpMethod || null,
-        "self.statusCode": statuscode,
-        type: logType,
-        queryStringParameters: event.queryStringParameters,
-        additionalDetails,
-    };
-};
-
-// In order for Pino to serialise errors correctly it either needs to be passed the error
-// directly or it needs to be under the key `err`
-const errorEntry = (event, error, additionalDetails) => {
-    // When there is an unknown error it is likely there is no error details passed, so
-    // we are initialising an empty error details
-    if (!error.details) {
-        error.details = {
-            funnelBackUrl: null,
-            status: null,
-            statusText: null,
-        };
+    if (error) {
+        entry.error = error;
+        if (error.details && error.details.statusCode) {
+            entry.details.statusCode = error.details.status;
+            entry.details.statusText = error.details.statusText;
+        }
     }
 
-    const logMessage = logEntry(event, error.details.status, LOG_TYPES.APPLICATION, additionalDetails);
-    logMessage.err = error;
-    return logMessage;
+    if (!entry.details.parameters) entry.details.parameters = event.queryStringParameters;
+    if (!entry.details.application) entry.details.application = "uoy-api-courses";
+
+    entry.details.clientIp = event?.requestContext?.identity?.sourceIp || null;
+
+    return entry;
 };
 
-module.exports = { logEntry, errorEntry };
+module.exports = { logEntry };

--- a/src/utils/logEntry.js
+++ b/src/utils/logEntry.js
@@ -6,8 +6,7 @@ const logEntry = (event, details, error) => {
     entry.details = entry.details ?? {};
 
     entry.details.application = "uoy-api-courses";
-
-    if (!entry.details.parameters) entry.details.parameters = event.queryStringParameters;
+    entry.details.parameters = event.queryStringParameters;
     entry.details.clientIp = event?.requestContext?.identity?.sourceIp || null;
 
     if (error) {

--- a/src/utils/logEntry.js
+++ b/src/utils/logEntry.js
@@ -5,18 +5,18 @@ const logEntry = (event, details, error) => {
 
     if (!entry.details) entry.details = {};
 
+    entry.details.application = "uoy-api-courses";
+
+    if (!entry.details.parameters) entry.details.parameters = event.queryStringParameters;
+    entry.details.clientIp = event?.requestContext?.identity?.sourceIp || null;
+
     if (error) {
         entry.error = error;
-        if (error.details && error.details.statusCode) {
+        if (error.details && error.details.status) {
             entry.details.statusCode = error.details.status;
             entry.details.statusText = error.details.statusText;
         }
     }
-
-    if (!entry.details.parameters) entry.details.parameters = event.queryStringParameters;
-    if (!entry.details.application) entry.details.application = "uoy-api-courses";
-
-    entry.details.clientIp = event?.requestContext?.identity?.sourceIp || null;
 
     return entry;
 };

--- a/src/utils/logEntry.js
+++ b/src/utils/logEntry.js
@@ -16,6 +16,7 @@ const logEntry = (event, details, error) => {
             entry.details.statusCode = error.details.status;
             entry.details.statusText = error.details.statusText;
         }
+
         if (!entry.error.type) entry.error.type = entry.error.name;
     }
 

--- a/src/utils/logEntry.js
+++ b/src/utils/logEntry.js
@@ -3,7 +3,7 @@ const logEntry = (event, details, error) => {
         details,
     };
 
-    if (!entry.details) entry.details = {};
+    entry.details = entry.details ?? {};
 
     entry.details.application = "uoy-api-courses";
 
@@ -17,7 +17,7 @@ const logEntry = (event, details, error) => {
             entry.details.statusText = error.details.statusText;
         }
 
-        if (!entry.error.type) entry.error.type = entry.error.name;
+        entry.error.type = entry.error.type ?? entry.error.name;
     }
 
     return entry;

--- a/src/utils/logEntry.test.js
+++ b/src/utils/logEntry.test.js
@@ -239,7 +239,7 @@ test("when no parameters are set in details, it will try to get them from the ev
     });
 });
 
-test("when parameters are set in details, do nothing", () => {
+test("don't use parameters from the event object when they have been passed in through the details object", () => {
     const event = {
         queryStringParameters: {},
         requestContext: {

--- a/src/utils/logEntry.test.js
+++ b/src/utils/logEntry.test.js
@@ -268,7 +268,7 @@ test.each([
     [new Error("Test Generic Error"), "Error"],
     [new SyntaxError("Test Syntax Error"), "SyntaxError"],
     [new DemoError("Test Demo Error"), "DemoError"],
-])("when the error type is not present, use the error name", async (error, expectedType) => {
+])("when the error type is not present, use the error name", (error, expectedType) => {
     const event = {
         queryStringParameters: {
             search: "physics",

--- a/src/utils/logEntry.test.js
+++ b/src/utils/logEntry.test.js
@@ -255,3 +255,25 @@ test("when parameters are set in details, do nothing", () => {
         foo: "bar",
     });
 });
+
+class DemoError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = "DemoError";
+    }
+}
+test.each([
+    [new Error("Test Generic Error"), "Error"],
+    [new SyntaxError("Test Syntax Error"), "SyntaxError"],
+    [new DemoError("Test Demo Error"), "DemoError"],
+])("when the error type is not present, use the error name", async (error, expectedType) => {
+    const event = {
+        queryStringParameters: {
+            search: "physics",
+        },
+    };
+
+    const result = logEntry(event, null, error);
+
+    expect(result.error.type).toEqual(expectedType);
+});

--- a/src/utils/logEntry.test.js
+++ b/src/utils/logEntry.test.js
@@ -169,6 +169,7 @@ test("Funnelback error log is correct", () => {
         statusText: "Internal Server Error",
     });
 });
+
 test("Generic error log is correct", () => {
     const event = {
         queryStringParameters: {
@@ -262,6 +263,7 @@ class DemoError extends Error {
         this.name = "DemoError";
     }
 }
+
 test.each([
     [new Error("Test Generic Error"), "Error"],
     [new SyntaxError("Test Syntax Error"), "SyntaxError"],

--- a/src/utils/logEntry.test.js
+++ b/src/utils/logEntry.test.js
@@ -239,24 +239,6 @@ test("when no parameters are set in details, it will try to get them from the ev
     });
 });
 
-test("don't use parameters from the event object when they have been passed in through the details object", () => {
-    const event = {
-        queryStringParameters: {},
-        requestContext: {
-            identity: {
-                sourceIp: "144.32.100.16",
-            },
-            apiId: "theApiId",
-        },
-    };
-
-    const result = logEntry(event, { parameters: { foo: "bar" } });
-
-    expect(result.details.parameters).toEqual({
-        foo: "bar",
-    });
-});
-
 class DemoError extends Error {
     constructor(message) {
         super(message);

--- a/src/utils/logger.js
+++ b/src/utils/logger.js
@@ -9,25 +9,21 @@ module.exports.logger = pino({
             return { level: label };
         },
     },
+    // Serializers parse a certain field returning a JSONifiable object
+    //
+    // By default Pino will serialize the `err` field for errors but we
+    // want to move that functionality to the `error` field instead
+    serializers: {
+        error: pino.stdSerializers.err,
+    },
     // Base controls what fields are included in the JSON
     // object, by default Pino includes fields like pid which
     // are not very relevant in a serverless context
-    base: {
-        "ip.client": null,
-        "ip.source": null,
-        "ip.sourcePort": null,
-        "req.user": null,
-        "req.service": "uoy-app-course-search",
-        correlationId: null,
-        "self.application": "uoy-api-courses",
-        "self.type": null,
-        "self.statusCode": null,
-        "self.version": "v1",
-        sensitive: false,
-        schemaURI: "https://university-of-york.github.io/uoy-api-courses/",
-        type: null,
-    },
+    base: {},
     // Whilst we could use `pino.stdTimeFunctions.isoTime`, it doesn't
     // have a key of `timestamp` which our AWS policy requires
     timestamp: () => `,"timestamp":"${new Date(Date.now()).toISOString()}"`,
+    // Whenever a string is given alongside an object to the logger it's the message.
+    // We're updating it from `msg` to `message` to match our AWS standard
+    messageKey: "message",
 });

--- a/src/utils/transformResponse.js
+++ b/src/utils/transformResponse.js
@@ -13,15 +13,13 @@ module.exports.transformResponse = (response) => {
 
 const transformDistanceLearning = (course) => {
     let distanceLearning;
-    if (course) {
-        if (typeof course.distanceLearning === "string") {
-            distanceLearning = course.distanceLearning.toLowerCase();
-        } else {
-            distanceLearning = "no";
-        }
-
-        course.distanceLearning = distanceLearning === "yes";
+    if (typeof course.distanceLearning === "string") {
+        distanceLearning = course.distanceLearning.toLowerCase();
+    } else {
+        distanceLearning = "no";
     }
+
+    course.distanceLearning = distanceLearning === "yes";
 
     return course;
 };


### PR DESCRIPTION
## Brief summary
This PR doesn't have too much to be mentioned other than the application will now log in our [application log fields](https://wiki.york.ac.uk/display/ittechdocs/AWS+Application+logging+fields) layout rather than the [policy](https://wiki.york.ac.uk/display/CLOUD/AWS-0008+-+Audit+Log+Policy).

As a little sidenote, `LOG_TYPES` and `errorEntry` have been removed, with log types being redundant, and `errorEntry`'s functionality merged into `logEntry`.

## Checklist
- [x] All tests passed.
- [x] :100: test coverage.
- [x] Compatible with CloudWatch Monitor's full templating.
- [x] Works in Sandbox.
- [x] Meets the [Jira ticket](https://jira.york.ac.uk/browse/CFIN-586) description.

## Logs previously looked like:
### info log
```
{
    "level": "info",
    "timestamp": "2021-11-19T14:27:56.424Z",
    "ip.client": "144.32.100.16",
    "ip.source": "144.32.100.16, 130.176.99.74",
    "ip.sourcePort": "443",
    "req.user": null,
    "req.service": "uoy-app-course-search",
    "correlationId": "4ies1z4xlf",
    "self.application": "uoy-api-courses",
    "self.type": "GET",
    "self.statusCode": 200,
    "self.version": "v1",
    "sensitive": false,
    "schemaURI": "https://university-of-york.github.io/uoy-api-courses/",
    "type": "audit",
    "queryStringParameters": {
        "max": "40",
        "search": "test"
    },
    "additionalDetails": {
        "numberOfMatches": 228
    }
}
```

### error log
```
{
    "level": "error",
    "timestamp": "2021-11-18T16:27:39.470Z",
    "ip.client": "144.32.100.16",
    "ip.source": "144.32.100.16, 130.176.99.154",
    "ip.sourcePort": "443",
    "req.user": null,
    "req.service": "uoy-app-course-search",
    "correlationId": "3ihr10kmhf",
    "self.application": "uoy-api-courses",
    "self.type": "GET",
    "self.statusCode": 500,
    "self.version": "v1",
    "sensitive": false,
    "schemaURI": "https://university-of-york.github.io/uoy-api-courses/",
    "type": "application",
    "queryStringParameters": {
        "max": "35",
        "search": "badtest"
    },
    "additionalDetails": null,
    "error": {
        "type": "FunnelbackError",
        "message": "There is a problem with the Funnelback search.",
        "stack": "FunnelbackError: There is a problem with the Funnelback search.\n    at Runtime.module.exports.courses [as handler] (/var/task/src/handler.js:41:19)\n    at processTicksAndRejections (internal/process/task_queues.js:95:5)",
        "name": "FunnelbackError",
        "details": {
            "funnelBackUrl": "https://york.funnelback.co.uk/search/?collection=courses&form=course-search&profile=_default_preview&smeta_contentType=course&query=badtest&num_ranks=35",
            "status": 500,
            "statusText": "Server Error"
        }
    },
    "message": "internal server error"
}
```

## Logs now look like:

### info log
```
{
    "level": "info",
    "timestamp": "2021-12-01T18:01:58.380Z",
    "details": {
        "numberOfMatches": 12,
        "statusCode": 200,
        "application": "uoy-api-courses",
        "parameters": {
            "search": "cs"
        },
        "clientIp": "test-invoke-source-ip"
    }
}
```

### error log
```
{
    "level": "error",
    "timestamp": "2021-12-01T18:02:11.095Z",
    "details": {
        "application": "uoy-api-courses",
        "parameters": {
            "search": "badcs"
        },
        "clientIp": "test-invoke-source-ip",
        "statusCode": 500,
        "statusText": "Server Error"
    },
    "error": {
        "type": "FunnelbackError",
        "message": "There is a problem with the Funnelback search.",
        "stack": "Error: There is a problem with the Funnelback search.\n    at Runtime.module.exports.courses [as handler] (/var/task/src/handler.js:40:19)\n    at processTicksAndRejections (internal/process/task_queues.js:95:5)",
        "details": {
            "funnelBackUrl": "https://york.funnelback.co.uk/search/?collection=courses&form=course-search&profile=_default_preview&smeta_contentType=course&query=badcs",
            "status": 500,
            "statusText": "Server Error"
        }
    },
    "message": "Internal Server Error"
}

```